### PR TITLE
Added methods getCurrentFrame, getTotalNumFrames, firstFrame, nextFra…

### DIFF
--- a/src/ofxAvVideoPlayer.cpp
+++ b/src/ofxAvVideoPlayer.cpp
@@ -959,3 +959,45 @@ string ofxAvVideoPlayer::getInfo(){
 	
 	return info.str();
 }
+
+int ofxAvVideoPlayer::getCurrentFrame() {
+    return (int)(round(getPositionMS()/(1000.0/getFps())));
+}
+
+int ofxAvVideoPlayer::getTotalNumFrames() {
+    if( !isLoaded() ) return 0;
+    return (int)(duration * 1000 * getFps());
+}
+
+void ofxAvVideoPlayer::firstFrame(){
+    if(duration>0) {
+        setPositionMS(0.0);
+    }
+}
+
+void ofxAvVideoPlayer::nextFrame(){
+    if(duration>0) {
+        setPositionMS(getPositionMS() + 1000.0/getFps());
+    }
+}
+
+void ofxAvVideoPlayer::previousFrame(){
+    if(duration>0) {
+        setPositionMS(getPositionMS() - 1000.0/getFps());
+    }}
+
+float ofxAvVideoPlayer::getHeight() const {
+   return (float)height;
+}
+
+float ofxAvVideoPlayer::getWidth() const {
+    return (float)width;
+}
+
+void ofxAvVideoPlayer::draw(float _x, float _y, float _w, float _h) {
+    getTexture().draw(_x,_y,_w,_h);
+}
+
+void ofxAvVideoPlayer::draw(float _x, float _y) {
+    draw(_x, _y, getWidth(), getHeight());
+}

--- a/src/ofxAvVideoPlayer.h
+++ b/src/ofxAvVideoPlayer.h
@@ -166,6 +166,20 @@ public:
 	void update();
 	
 	string getInfo();
+
+    int getCurrentFrame();
+    int getTotalNumFrames();
+
+    void    firstFrame();
+    void    nextFrame();
+    void    previousFrame();
+
+    float   getHeight() const;
+    float   getWidth() const;
+
+    void    draw(float x, float y, float w, float h);
+    void    draw(float x, float y);
+
 	
 private:
 	long long duration;


### PR DESCRIPTION
Hi Kritzikratzi

I have added the following methods getCurrentFrame, getTotalNumFrames, firstFrame, nextFrame, previousFrame, getHeight, getWidth, draw(x,y,w,h), draw(x,y) to make it more compatible with the standard videoplayer in OF.

It is clear to me that especially nextFrame and previousFrame currently very much depend on the used codec. I have not understood yet, how this works under the hood, but I hope there exists the possibility to improve the setPosition() method. I have no idea how though other than that VLC and the old OSX software MPEG Streamclip handles frame navigation, independent of the codecs, very well. 

I understand the concept of I, P and B frames and the slices concept in the H264 standard probably does not make things easier. To get proper frame navigation to work the respective I frames and the in-betweens have to be cached I guess. Maybe you can point me in the right direction how to do that.

My programming knowledge is limited, but I really would like to reach that perfection :-)

Cheers
Jakob
