### PR TITLE
added linux support

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,8 +29,7 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES = libs/avcodec/include
-	ADDON_INCLUDES += src
+	#ADDON_INCLUDES = 
 		
 	# any special flag that should be passed to the compiler when using this
 	# addon
@@ -60,8 +59,25 @@ common:
 	# when parsing the file system looking for libraries exclude this for all or
 	# a specific platform
 	# ADDON_LIBS_EXCLUDE =
+linux:
+	ADDON_LDFLAGS = -lavcodec -lavutil -lavformat -lswresample -lswscale
+	ADDON_SOURCES_EXCLUDE = libs/%	
+	ADDON_INCLUDES_EXCLUDE = libs/%	
+	
+linux64:
+	ADDON_LDFLAGS = -lavcodec -lavutil -lavformat -lswresample -lswscale	
+	ADDON_SOURCES_EXCLUDE = libs/%
+	ADDON_INCLUDES_EXCLUDE = libs/%		
+	
+osx:
+	ADDON_INCLUDES = libs/avcodec/include
+	ADDON_INCLUDES += src
+	
 msys2:
-	#ADDON_INCLUDES_EXCLUDE = libs/avcodec/include-vs/%	
+	ADDON_INCLUDES = libs/avcodec/include
+	ADDON_INCLUDES += src	
 
 vs: 
 	ADDON_INCLUDES += libs/avcodec/include-vs
+	ADDON_INCLUDES = libs/avcodec/include
+	ADDON_INCLUDES += src

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -78,6 +78,6 @@ msys2:
 	ADDON_INCLUDES += src	
 
 vs: 
-	ADDON_INCLUDES += libs/avcodec/include-vs
-	ADDON_INCLUDES = libs/avcodec/include
+	ADDON_INCLUDES = libs/avcodec/include-vs
+	ADDON_INCLUDES += libs/avcodec/include
 	ADDON_INCLUDES += src


### PR DESCRIPTION
Hi,
I rewrote the addons_config.mk to support Linux as well. On my Ubuntu 16.04 machine, I couldn't use the bundled headers and libs as I got errors. So I ignored them and got the system libs instead and it worked fine. This might not work forever, but at least for the moment it does.

